### PR TITLE
Fix #22: Crash at startup since version 1.3.0

### DIFF
--- a/src/libexec/git-core/git-webui
+++ b/src/libexec/git-core/git-webui
@@ -310,7 +310,7 @@ if __name__ == '__main__':
 
     args.port = get_setting_string(args, 'port', None)
     port = int(args.port) if args.port is not None else 8000
-    host = get_setting_string(args, 'host', "")
+    host = get_setting_string(args, 'host', "localhost")
     httpd = None
     while httpd is None:
         try:


### PR DESCRIPTION
I propose to fix #22 by binding the http server to localhost.
It seems appropriate since the web browser is opening with http://localhost:8000 when host is not configured nor passed as an argument.