### PR TITLE
Use os.path.realpath instead of os.path.abspath for web_root

### DIFF
--- a/release/libexec/git-core/git-webui
+++ b/release/libexec/git-core/git-webui
@@ -68,7 +68,7 @@ class WebUiRequestHandler(SimpleHTTPRequestHandler):
 
     @classmethod
     def initialize(cls, repo_root):
-        web_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0]))))
+        web_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(sys.argv[0]))))
         web_root = os.path.join(web_root, "share", "git-webui", "webui")
         WebUiRequestHandler.WEB_ROOT = web_root
         WebUiRequestHandler.REPO_ROOT = repo_root

--- a/src/libexec/git-core/git-webui
+++ b/src/libexec/git-core/git-webui
@@ -68,7 +68,7 @@ class WebUiRequestHandler(SimpleHTTPRequestHandler):
 
     @classmethod
     def initialize(cls, repo_root):
-        web_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0]))))
+        web_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(sys.argv[0]))))
         web_root = os.path.join(web_root, "share", "git-webui", "webui")
         WebUiRequestHandler.WEB_ROOT = web_root
         WebUiRequestHandler.REPO_ROOT = repo_root


### PR DESCRIPTION
When installed via Homebrew, git-webui is unable to locate and render any assets from `web_root` if using abspath. This PR fixes that.