### PR TITLE
Allow utf-8 symbols in branch names for Python 2.7

### DIFF
--- a/release/libexec/git-core/git-webui
+++ b/release/libexec/git-core/git-webui
@@ -30,6 +30,8 @@ if sys.version > '3':
     from http.server import SimpleHTTPRequestHandler, HTTPServer
     from urllib.parse import unquote, urlparse
 else:
+    reload(sys)
+    sys.setdefaultencoding("utf-8")
     from SimpleHTTPServer import SimpleHTTPRequestHandler
     from BaseHTTPServer import HTTPServer
     from urllib import unquote

--- a/src/libexec/git-core/git-webui
+++ b/src/libexec/git-core/git-webui
@@ -30,6 +30,8 @@ if sys.version > '3':
     from http.server import SimpleHTTPRequestHandler, HTTPServer
     from urllib.parse import unquote, urlparse
 else:
+    reload(sys)
+    sys.setdefaultencoding("utf-8")
     from SimpleHTTPServer import SimpleHTTPRequestHandler
     from BaseHTTPServer import HTTPServer
     from urllib import unquote


### PR DESCRIPTION
If a branch name contains some non-ascii utf-8 symbols and I try to open that branch with `git-webui` then an exception is thrown like:
```
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 42527)
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 655, in __init__
    self.handle()
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 340, in handle
    self.handle_one_request()
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 328, in handle_one_request
    method()
  File "/home/user/git-webui/release/libexec/git-core/git-webui", line 130, in do_POST
    cmd = shlex.split("git " + codecs.decode(args, "utf-8"))
  File "/usr/lib/python2.7/shlex.py", line 275, in split
    lex = shlex(s, posix=posix)
  File "/usr/lib/python2.7/shlex.py", line 25, in __init__
    instream = StringIO(instream)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 78-86: ordinal not in range(128)
----------------------------------------
```
To avoid such errors this PR provides a simple fix for Python2.x.
