### PR TITLE
bugfix: check for client-ip instead of server-hostname sort-of fixes: #48

### DIFF
--- a/src/libexec/git-core/git-webui
+++ b/src/libexec/git-core/git-webui
@@ -142,7 +142,7 @@ class WebUiRequestHandler(SimpleHTTPRequestHandler):
 
 
     def is_view_only(self):
-        host = self.headers.get("Host", "").split(":")[0]
+        host = self.client_address[0]
         return host not in allowed_hosts
 
 


### PR DESCRIPTION
do not check for how the server is called in a request but for the ip of the client. sort-of fixes: #48